### PR TITLE
Update for Arduino Core V3.0.0

### DIFF
--- a/src/HomieDevice.cpp
+++ b/src/HomieDevice.cpp
@@ -305,11 +305,9 @@ void HomieDevice::Loop()
 
 
 	static uint32_t ulFreeHeap=0xFFFFFFF;
-#if defined(ARDUINO_ARCH_ESP8266)
-	static uint16_t ulFreeHeapContig=0xFFFF;
-	static uint8_t uHeapFrag=0;
-#else
 	static uint32_t ulFreeHeapContig=0xFFFFFFF;
+#if defined(ARDUINO_ARCH_ESP8266)
+	static uint8_t uHeapFrag=0;	
 #endif
 
 	if(bEvenSecond)

--- a/src/HomieDevice.cpp
+++ b/src/HomieDevice.cpp
@@ -305,9 +305,13 @@ void HomieDevice::Loop()
 
 
 	static uint32_t ulFreeHeap=0xFFFFFFF;
-	static uint32_t ulFreeHeapContig=0xFFFFFFF;
 #if defined(ARDUINO_ARCH_ESP8266)
-	static uint8_t uHeapFrag=0;	
+	static uint8_t uHeapFrag=0;
+	#if ARDUINO_ESP8266_GIT_DESC < 3
+		static uint16_t ulFreeHeapContig=0xFFFF;
+	#else
+		static uint32_t ulFreeHeapContig=0xFFFFFFF;
+	#endif
 #endif
 
 	if(bEvenSecond)

--- a/src/HomieDevice.cpp
+++ b/src/HomieDevice.cpp
@@ -307,7 +307,7 @@ void HomieDevice::Loop()
 	static uint32_t ulFreeHeap=0xFFFFFFF;
 #if defined(ARDUINO_ARCH_ESP8266)
 	static uint8_t uHeapFrag=0;
-	#if ARDUINO_ESP8266_GIT_DESC < 3
+	#if !defined(ARDUINO_ESP8266_MAJOR) || ARDUINO_ESP8266_MAJOR < 3
 		static uint16_t ulFreeHeapContig=0xFFFF;
 	#else
 		static uint32_t ulFreeHeapContig=0xFFFFFFF;


### PR DESCRIPTION
The return type of ESP.getMaxFreeBlockSize() in Arduino Core is changed from uint16_t to uint32_t  on commit https://github.com/esp8266/Arduino/pull/8440/commits/25821101f355dbd02576901092c8bcb29a3a624c

So this fix allow to use the Arduino Core up to the newest current version (3.1.2)